### PR TITLE
BE-14: update to have structured response

### DIFF
--- a/src/main/java/infrastructure/CustomerProfileResources.java
+++ b/src/main/java/infrastructure/CustomerProfileResources.java
@@ -1,6 +1,8 @@
 package infrastructure;
 
+import domain.profile.CustomerProfile;
 import domain.profile.CustomerProfileService;
+import infrastructure.dto.ApiResponse;
 import infrastructure.dto.in.profile.CreateCustomerProfileDto;
 import infrastructure.dto.in.profile.UpdateCustomerProfileDto;
 import infrastructure.dto.out.profile.CustomerProfilesDetailsDto;
@@ -10,6 +12,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
 import java.util.Optional;
 
@@ -22,33 +25,66 @@ public class CustomerProfileResources {
 
     @POST
     @Path("/create-profile")
-    public CustomerProfilesDetailsDto createCustomerProfile(CreateCustomerProfileDto createCustomerProfileDto) {
-        return CustomerProfilesDetailsDto.fromDomain(customerProfileService.createProfile(createCustomerProfileDto.toDomain()));
+    public Response createCustomerProfile(CreateCustomerProfileDto createCustomerProfileDto) {
+        CustomerProfilesDetailsDto createdCustomerProfile =
+                CustomerProfilesDetailsDto.fromDomain(customerProfileService.createProfile(createCustomerProfileDto.toDomain()));
+        ApiResponse<CustomerProfilesDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                             200,
+                                                                             Optional.of(createdCustomerProfile));
+        return Response.ok(response).build();
     }
 
     @POST
     @Path("/get-profile/{customerId}")
-    public Optional<CustomerProfilesDetailsDto> getCustomerProfile(@PathParam("customerId") String customerId) {
-        return Optional.ofNullable(CustomerProfilesDetailsDto.fromDomain(customerProfileService.getCustomerProfile(customerId)
-                                                                                               .orElseThrow(() -> new RuntimeException(
-                                                                                                       "Cannot find listing with id " + customerId + "."))));
+    public Response getCustomerProfile(@PathParam("customerId") String customerId) {
+        Optional<CustomerProfile> fetchedCustomerProfile =
+                customerProfileService.getCustomerProfile(customerId);
+
+        ApiResponse<CustomerProfilesDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                             200,
+                                                                             Optional.empty());
+
+        if (fetchedCustomerProfile.isPresent()) {
+            response.setData(Optional.of(CustomerProfilesDetailsDto.fromDomain(
+                    fetchedCustomerProfile.get())));
+        } else {
+            response.setMessage(Optional.of("Cannot find customer with id " + customerId + "."));
+        }
+
+        return Response.ok(response).build();
     }
 
     @POST
     @Path("/update-profile")
-    public Optional<CustomerProfilesDetailsDto> updateCustomerProfile(UpdateCustomerProfileDto updateCustomerProfileDto) {
-        return Optional.ofNullable(CustomerProfilesDetailsDto.fromDomain(
-                customerProfileService.updateCustomerProfile(updateCustomerProfileDto.toDomain())
-                                      .orElseThrow(() -> new RuntimeException(
-                                              "Cannot update customer with id " + updateCustomerProfileDto.id() + "."))));
+    public Response updateCustomerProfile(UpdateCustomerProfileDto updateCustomerProfileDto) {
+        Optional<CustomerProfile> updatedCustomerProfile =
+                customerProfileService.updateCustomerProfile(updateCustomerProfileDto.toDomain());
+        ApiResponse<CustomerProfilesDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                             200,
+                                                                             Optional.empty());
+        if (updatedCustomerProfile.isEmpty()) {
+            response.setMessage(Optional.of("Cannot find customer with id " + updateCustomerProfileDto.id() + "."));
+        } else {
+            response.setData(Optional.of(CustomerProfilesDetailsDto.fromDomain(updatedCustomerProfile.get())));
+        }
+        return Response.ok(response).build();
     }
 
     @POST
     @Path("/delete-profile/{customerId}")
-    public Optional<CustomerProfilesDetailsDto> deleteCustomerProfile(@PathParam("customerId") String customerId) {
-        return Optional.ofNullable(CustomerProfilesDetailsDto.fromDomain(customerProfileService.deleteCustomerProfile(customerId)
-                                                                                               .orElseThrow(() -> new RuntimeException(
-                                                                                                       "Cannot find customer with id " + customerId + "."))));
+    public Response deleteCustomerProfile(@PathParam("customerId") String customerId) {
+        ApiResponse<CustomerProfilesDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                             200,
+                                                                             Optional.empty());
+
+        Optional<CustomerProfile> deletedCustomerProfile = customerProfileService.deleteCustomerProfile(customerId);
+        if (deletedCustomerProfile.isEmpty()) {
+            response.setMessage(Optional.of("Cannot find customer with id " + customerId + ", as it's not found."));
+        } else {
+            response.setData(Optional.of(CustomerProfilesDetailsDto.fromDomain(deletedCustomerProfile.get())));
+        }
+
+        return Response.ok(response).build();
     }
 
 }

--- a/src/main/java/infrastructure/ListingResources.java
+++ b/src/main/java/infrastructure/ListingResources.java
@@ -1,6 +1,8 @@
 package infrastructure;
 
+import domain.listing.ListingDetails;
 import domain.listing.ListingService;
+import infrastructure.dto.ApiResponse;
 import infrastructure.dto.in.listing.CreateListingDto;
 import infrastructure.dto.in.listing.UpdateListingDto;
 import infrastructure.dto.out.listing.ListingDetailsDto;
@@ -10,6 +12,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 
 import java.util.Optional;
 
@@ -23,31 +26,57 @@ public class ListingResources {
 
     @POST
     @Path("/create-listing")
-    public ListingDetailsDto createListing(CreateListingDto createListingDto) {
-        return ListingDetailsDto.fromDomain(listingService.createListing(createListingDto.toDomain()));
+    public Response createListing(CreateListingDto createListingDto) {
+        ListingDetails createdListing = listingService.createListing(createListingDto.toDomain());
+        ApiResponse<ListingDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                    200,
+                                                                    Optional.of(ListingDetailsDto.fromDomain(createdListing)));
+        return Response.ok(response).build();
     }
 
     @POST
     @Path("/get-listing/{listingId}")
-    public Optional<ListingDetailsDto> getListing(@PathParam("listingId") String listingId) {
-        return Optional.ofNullable(ListingDetailsDto.fromDomain(listingService.getListing(listingId)
-                                                                              .orElseThrow(() -> new RuntimeException(
-                                                                                      "Cannot find listing with id " + listingId + "."))));
+    public Response getListing(@PathParam("listingId") String listingId) {
+        Optional<ListingDetails> fetchedListing = listingService.getListing(listingId);
+        ApiResponse<ListingDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                  200,
+                                                                  Optional.empty());
+        if (fetchedListing.isPresent()) {
+            response.setData(Optional.of(ListingDetailsDto.fromDomain(fetchedListing.get())));
+        } else {
+            response.setMessage(Optional.of("Cannot find listing with id " + listingId + "."));
+        }
+
+        return Response.ok(response).build();
     }
 
     @POST
     @Path("/update-listing")
-    public Optional<ListingDetailsDto> updateListing(UpdateListingDto updateListingDto) {
-        return Optional.ofNullable(ListingDetailsDto.fromDomain(listingService.updateListing(updateListingDto.toDomain())
-                                                                              .orElseThrow(() -> new RuntimeException(
-                                                                                      "Cannot update listing with id " + updateListingDto.id() + "."))));
+    public Response updateListing(UpdateListingDto updateListingDto) {
+        Optional<ListingDetails> updatedListing = listingService.updateListing(updateListingDto.toDomain());
+        ApiResponse<ListingDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                  200,
+                                                                  Optional.empty());
+        if (updatedListing.isPresent()) {
+            response.setData(Optional.of(ListingDetailsDto.fromDomain(updatedListing.get())));
+        } else {
+            response.setMessage(Optional.of("Cannot update listing with id " + updateListingDto.id() + " as listing was not found with given ID."));
+        }
+        return Response.ok(response).build();
     }
 
     @POST
     @Path("/delete-listing/{listingId}")
-    public Optional<ListingDetailsDto> deleteListing(@PathParam("listingId") String listingId) {
-        return Optional.ofNullable(ListingDetailsDto.fromDomain(listingService.deleteListing(listingId)
-                                                                              .orElseThrow(() -> new RuntimeException(
-                                                                                      "Cannot find listing with id " + listingId + "."))));
+    public Response deleteListing(@PathParam("listingId") String listingId) {
+        Optional<ListingDetails> deletedListing = listingService.deleteListing(listingId);
+        ApiResponse<ListingDetailsDto> response = new ApiResponse<>(Optional.empty(),
+                                                                  200,
+                                                                  Optional.empty());
+        if (deletedListing.isPresent()) {
+            response.setData(Optional.of(ListingDetailsDto.fromDomain(deletedListing.get())));
+        } else {
+            response.setMessage(Optional.of("Cannot delete listing with id " + listingId + " as listing was not found with given ID."));
+        }
+        return Response.ok(response).build();
     }
 }

--- a/src/main/java/infrastructure/dto/ApiResponse.java
+++ b/src/main/java/infrastructure/dto/ApiResponse.java
@@ -1,0 +1,18 @@
+package infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Optional;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ApiResponse<T> {
+    private Optional<String> message;
+    private int code;
+    private Optional<T> data;
+}

--- a/src/main/java/infrastructure/dto/out/listing/ListingDetailsDto.java
+++ b/src/main/java/infrastructure/dto/out/listing/ListingDetailsDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ListingDetailsDto(String id,
                                 String title,
                                 String description,

--- a/src/main/java/infrastructure/dto/out/profile/CustomerProfilesDetailsDto.java
+++ b/src/main/java/infrastructure/dto/out/profile/CustomerProfilesDetailsDto.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import java.util.Optional;
 
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record CustomerProfilesDetailsDto(String id,
                                          String name,
                                          Optional<String> email,


### PR DESCRIPTION
### Description
- Response now have structured response which has two optional fields of: `message` and `data` and a required field of `code` which represents the status code of the response.

### Tests
- How did you test this change? Or how can someone test it?
  - Running the project locally and test in postman with existing collection
  - Sample response:
  ```json
    {
        "code": 200,
        "data": {
            "id": "4ff7a727-8d83-49c9-a70d-c6b40c0b8c81",
            "title": "First listing",
            "description": "description",
            "price": 0.0,
            "longitude": 12.233,
            "latitude": 0.0,
            "category": "BOOKS",
            "userId": "First listing",
            "status": "ACTIVE",
            "starCount": 0,
            "createdAt": "2024-02-12T06:43:15.309Z",
            "updatedAt": "2024-02-12T06:43:15.309Z"
        }
    }
  ```
    - and exception:
    ```json
    {
        "message": "Cannot find listing with id 4ff7a727-8d83-49c9-a70d-c6b40c0b8c81s.",
        "code": 200
    }
    ```

### Screenshots
If applicable, attach screenshots to explain the changes.

![Screenshot 2024-02-12 020625](https://github.com/ECE651-Group-15/backend/assets/48367018/616b1cb2-c72f-409c-accc-64eaa66ad57c)
![Screenshot 2024-02-12 020651](https://github.com/ECE651-Group-15/backend/assets/48367018/1df6ba81-124c-4ef4-8c63-bc3450534286)
