### PR TITLE
BE-37: fixed the domain method, when FE not passing long and lat, NPE was thrown

### DIFF
--- a/src/main/java/infrastructure/sql/entity/CustomerProfileEntity.java
+++ b/src/main/java/infrastructure/sql/entity/CustomerProfileEntity.java
@@ -70,8 +70,8 @@ public class CustomerProfileEntity {
                                                  .email(this.email)
                                                  .password(this.password)
                                                  .phone(Optional.of(this.phone))
-                                                 .longitude(Optional.of(this.longitude))
-                                                 .latitude(Optional.of(this.latitude))
+                                                 .longitude(Optional.ofNullable(this.longitude))
+                                                 .latitude(Optional.ofNullable(this.latitude))
                                                  .build();
         if (this.postedListings != null) {
             List<String> listingIds = this.postedListings.stream()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkus.banner.enabled=false
 
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
-quarkus.datasource.password=123
+quarkus.datasource.password=Appear7711drain!
 quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/mydatabase
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.database.generation=update


### PR DESCRIPTION
### Description
- Describe the changes in this Pull Request, and related ticket if applicable.
  - This ticket fixed the issue when long and lat was not passed from FE when creating customer, NPE will be thrown when using getCustomer profile related endpoints.

### Tests
- How did you test this change? Or how can someone test it?
  - Tested locally in postman. 
- Is there any additional tests needed for this change?
  - Deploy in aws and test remotely

### Screenshots
If applicable, attach screenshots to explain the changes.
![image](https://github.com/ECE651-Group-15/backend/assets/48367018/207ffd38-e469-4f82-a7bf-bd5339a78bdd)

