### PR TITLE
Be 53: Add endpoint to get completed listings for a customer

### DIFF
--- a/src/main/java/domain/listing/ListingService.java
+++ b/src/main/java/domain/listing/ListingService.java
@@ -57,7 +57,6 @@ public class ListingService {
         List<ListingEntity> postedListings = customerProfileEntity.get().getPostedListings();
         postedListings.add(listingEntity);
         customerProfileEntity.get().setPostedListings(postedListings);
-//        customerProfileRepository.updateCustomerProfile(customerProfileEntity.get());
         listingRepository.save(listingEntity);
         return Optional.of(listingDetails);
     }
@@ -213,8 +212,8 @@ public class ListingService {
                 }
                 String listingId = listingIds.get().get(i);
                 Optional<ListingDetails> listing = listingRepository.getListing(listingId)
-                                                                    .map(ListingEntity::toDomain);
-                listing.ifPresent(list -> listings.add(list));
+																	.map(ListingEntity::toDomain);
+                listing.ifPresent(listings::add);
             }
             listings.sort((l1, l2) -> Long.compare(l2.getUpdatedAt(), l1.getUpdatedAt()));
             return listings;
@@ -224,7 +223,8 @@ public class ListingService {
     public List<ListingWithCustomerInfo> getListingAndCustomerByPage(int page, int pageSize) {
         return listingRepository.getListingPage(page, pageSize)
                                 .stream()
-                                .map(listingEntity -> {
+								.filter(listingEntity -> listingEntity.getStatus().equals(ListingStatus.ACTIVE))
+								.map(listingEntity -> {
                                     Optional<CustomerProfileEntity> customerProfileEntity =
                                             customerProfileRepository.getCustomerProfile(listingEntity.getCustomerProfile().getId());
                                     return customerProfileEntity.map(customerProfile -> ListingWithCustomerInfo.builder()
@@ -242,6 +242,7 @@ public class ListingService {
 	public List<ListingDetails> searchListing(SearchListing searchListing) {
 		return listingRepository.getListingByTitle(searchListing.getTitle())
 								.stream()
+								.filter(listingEntity -> listingEntity.getStatus().equals(ListingStatus.ACTIVE))
 								.map(ListingEntity::toDomain)
 								.toList();
 	}

--- a/src/main/java/infrastructure/CustomerListingResources.java
+++ b/src/main/java/infrastructure/CustomerListingResources.java
@@ -163,7 +163,10 @@ public class CustomerListingResources {
                                                                                  fetchedCustomerProfile.get().getStarredListingIds());
             response.setData(Optional.of(StarredListingPageDto.builder()
                                                               .starredListings(
-                                                                      starredListings.stream().map(ListingDetailsDto::fromDomain).toList())
+                                                                      starredListings.stream()
+																					 .filter(listingDetails -> listingDetails.getStatus()
+																															 .equals(ListingStatus.ACTIVE))
+																					 .map(ListingDetailsDto::fromDomain).toList())
                                                               .build()));
         } else {
             response.setMessage(Optional.of("Cannot find customer with id " + customerListingsDto.customerId() + "."));

--- a/src/main/java/infrastructure/CustomerListingResources.java
+++ b/src/main/java/infrastructure/CustomerListingResources.java
@@ -2,15 +2,17 @@ package infrastructure;
 
 import domain.listing.ListingDetails;
 import domain.listing.ListingService;
+import domain.listing.ListingStatus;
 import domain.profile.CustomerProfile;
 import domain.profile.CustomerProfileService;
 import infrastructure.dto.ApiResponse;
 import infrastructure.dto.in.listing.PageDto;
 import infrastructure.dto.in.listing.StarListingDto;
 import infrastructure.dto.in.profile.GetCustomerListingsDto;
-import infrastructure.dto.out.listing.ListingWithCustomerInfoDto;
+import infrastructure.dto.out.listing.CompletedListingPageDto;
 import infrastructure.dto.out.listing.ListingDetailsDto;
 import infrastructure.dto.out.listing.ListingPageDetailsDto;
+import infrastructure.dto.out.listing.ListingWithCustomerInfoDto;
 import infrastructure.dto.out.listing.PostedListingPageDto;
 import infrastructure.dto.out.listing.StarredListingPageDto;
 import infrastructure.result.CustomerStarResult;
@@ -68,12 +70,12 @@ public class CustomerListingResources {
 
 		ListingUnStarResult listingUnStarResult = listingService.unStarListing(starListingDto.toDomain());
 		CustomerUnStarResult customerUnStarResult = customerProfileService.unStarListing(starListingDto.toDomain());
-		if (listingUnStarResult.isCustomerNotFound() || customerUnStarResult.isCustomerNotFound()) {
+		if (listingUnStarResult.isCustomerNotFound()) {
 			response.setMessage(Optional.of("Cannot find customer with id " + starListingDto.customerId() + "."));
 			response.setCode(4001);
 			return Response.ok(response).build();
 		}
-		if (listingUnStarResult.isListingNotFound() || customerUnStarResult.isListingNotFound()) {
+		if (customerUnStarResult.isListingNotFound()) {
 			response.setMessage(Optional.of("Cannot find listing with id " + starListingDto.listingId() + "."));
 			response.setCode(4001);
 			return Response.ok(response).build();
@@ -86,10 +88,8 @@ public class CustomerListingResources {
 
     @POST
     @Path("/get-customer-posted-listings")
-
     public Response getCustomerPostedListings(GetCustomerListingsDto getCustomerListingsDto) {
-
-        Optional<CustomerProfile> fetchedCustomerProfile = customerProfileService.getCustomerProfile(getCustomerListingsDto.customerId());
+        Optional<CustomerProfile> fetchedCustomerProfile = getCustomerProfile(getCustomerListingsDto.customerId());
         ApiResponse<PostedListingPageDto> response = new ApiResponse<>(Optional.empty(), 200, Optional.empty());
 
         if (getCustomerListingsDto.page() < 0) {
@@ -103,7 +103,10 @@ public class CustomerListingResources {
                                                                                 fetchedCustomerProfile.get().getPostedListingIds());
             response.setData(Optional.of(PostedListingPageDto.builder()
                                                              .postedListings(
-                                                                     postedListings.stream().map(ListingDetailsDto::fromDomain).toList())
+																	 postedListings.stream()
+																				   .filter(listingDetails -> listingDetails.getStatus()
+																														   .equals(ListingStatus.ACTIVE))
+																				   .map(ListingDetailsDto::fromDomain).toList())
                                                              .build()));
         } else {
             response.setMessage(Optional.of("Cannot find customer with id " + getCustomerListingsDto.customerId() + "."));
@@ -113,10 +116,40 @@ public class CustomerListingResources {
         return Response.ok(response).build();
     }
 
+	@POST
+	@Path("/get-customer-completed-listings")
+	public Response getCustomerCompletedListings(GetCustomerListingsDto getCustomerListingsDto) {
+		Optional<CustomerProfile> fetchedCustomerProfile = getCustomerProfile(getCustomerListingsDto.customerId());
+		ApiResponse<CompletedListingPageDto> response = new ApiResponse<>(Optional.empty(), 200, Optional.empty());
+
+		if (getCustomerListingsDto.page() < 0) {
+			response.setMessage(Optional.of("Page number cannot be negative."));
+			response.setCode(4001);
+			return Response.ok(response).build();
+		}
+		if (fetchedCustomerProfile.isPresent()) {
+			List<ListingDetails> postedListings = listingService.getListingPage(getCustomerListingsDto.page(),
+																				getCustomerListingsDto.pageSize(),
+																				fetchedCustomerProfile.get().getPostedListingIds());
+			response.setData(Optional.of(CompletedListingPageDto.builder()
+																.completedListings(
+																		postedListings.stream()
+																					  .filter(listingDetails -> listingDetails.getStatus()
+																															  .equals(ListingStatus.INACTIVE))
+																					  .map(ListingDetailsDto::fromDomain).toList())
+																.build()));
+		} else {
+			response.setMessage(Optional.of("Cannot find customer with id " + getCustomerListingsDto.customerId() + "."));
+			response.setCode(4001);
+		}
+
+		return Response.ok(response).build();
+	}
+
     @POST
     @Path("/starred-listings")
     public Response getStarredListings(GetCustomerListingsDto customerListingsDto) {
-        Optional<CustomerProfile> fetchedCustomerProfile = customerProfileService.getCustomerProfile(customerListingsDto.customerId());
+        Optional<CustomerProfile> fetchedCustomerProfile = getCustomerProfile(customerListingsDto.customerId());
         ApiResponse<StarredListingPageDto> response = new ApiResponse<>(Optional.empty(), 200, Optional.empty());
 
         if (customerListingsDto.page() < 0) {
@@ -184,4 +217,8 @@ public class CustomerListingResources {
         response.setData(Optional.ofNullable(listingAndCustomerDetails));
         return Response.ok(response).build();
     }
+
+	Optional<CustomerProfile> getCustomerProfile(String customerId) {
+		return customerProfileService.getCustomerProfile(customerId);
+	}
 }

--- a/src/main/java/infrastructure/dto/out/listing/CompletedListingPageDto.java
+++ b/src/main/java/infrastructure/dto/out/listing/CompletedListingPageDto.java
@@ -1,0 +1,12 @@
+package infrastructure.dto.out.listing;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Builder
+public class CompletedListingPageDto {
+	public final List<ListingDetailsDto> completedListings;
+}


### PR DESCRIPTION
### Description
- In this ticket, I've added the endpoint to get completed listings for a customer. Also, filter posted listing, starred listings by listing status, not returning `INAVTIVE` listings to customers.

### Tests
- How did you test this change? Or how can someone test it?
  - Testing locally in postman.
  - When a listings status is `ACTIVE`, it will show up in my starred listings
![image](https://github.com/ECE651-Group-15/backend/assets/48367018/497dde27-a05f-411b-8562-a060ae1dcc93)
   - When a listings status is `INAVTIVE`, it will disappear in my starred listings:
![image](https://github.com/ECE651-Group-15/backend/assets/48367018/beb257b7-30b8-4507-9fe5-17ef99656b0b)
![image](https://github.com/ECE651-Group-15/backend/assets/48367018/ed17bb7c-e4d8-4a17-a590-8fefd7a96657)
  - Also the completed listing will show in this endpoint: `get-customer-completed-listings`:
![image](https://github.com/ECE651-Group-15/backend/assets/48367018/77af2e46-db21-4ca3-a04f-d620ef4f301b)


- Is there any additional tests needed for this change?
  - Test together with frontend.

